### PR TITLE
Add test fixtures and API endpoint tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,25 @@
 """Pytest configuration and shared fixtures."""
 
 import importlib
+from datetime import datetime, timezone
+from uuid import uuid4
 from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
-from main import app
 from app.core.auth import get_current_user, get_current_admin_user
+
 supabase_module = importlib.import_module("app.core.supabase")
 
 
 @pytest.fixture
-def mock_supabase(monkeypatch):
+def mock_supabase(mock_rate_limiter, monkeypatch):
     """Provide a mocked Supabase service for tests."""
     mock = MagicMock()
+    mock.get_client.return_value = MagicMock()
+    mock.fetch_by_id = MagicMock()
+    mock.get_by_id = MagicMock()
     monkeypatch.setattr(supabase_module, "supabase", mock)
 
     modules = [
@@ -37,6 +42,36 @@ def mock_supabase(monkeypatch):
     return mock
 
 
+@pytest.fixture(autouse=True, scope="session")
+def mock_rate_limiter():
+    """Disable rate limiting during tests."""
+    rate_limiter_module = importlib.import_module("app.core.rate_limiter")
+
+    class DummyLimiter:
+        def limit(self, *args, **kwargs):
+            def decorator(func):
+                return func
+            return decorator
+
+        def exempt(self, func):
+            return func
+
+    rate_limiter_module.redis_client = MagicMock()
+    rate_limiter_module.limiter = DummyLimiter()
+
+    import slowapi.middleware
+
+    class DummyMiddleware:
+        def __init__(self, app):
+            self.app = app
+
+        async def __call__(self, scope, receive, send):
+            await self.app(scope, receive, send)
+
+    slowapi.middleware.SlowAPIMiddleware = DummyMiddleware
+    return rate_limiter_module.limiter
+
+
 @pytest.fixture
 def mock_current_user():
     async def _mock_current_user():
@@ -56,8 +91,54 @@ def mock_current_admin_user():
 @pytest.fixture
 def client(mock_current_user, mock_current_admin_user, mock_supabase):
     """Test client with authentication dependencies overridden."""
+    from main import app
+
     app.dependency_overrides[get_current_user] = mock_current_user
     app.dependency_overrides[get_current_admin_user] = mock_current_admin_user
     with TestClient(app) as test_client:
         yield test_client
     app.dependency_overrides.clear()
+
+
+@pytest.fixture
+def player_data():
+    """Sample player data used in endpoint tests."""
+    return {
+        "id": str(uuid4()),
+        "user_id": str(uuid4()),
+        "gamertag": "TestPlayer",
+        "region": "NA",
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+        "is_active": True,
+    }
+
+
+@pytest.fixture
+def event_data():
+    """Sample event data used in endpoint tests."""
+    now = datetime.now(timezone.utc)
+    return {
+        "id": str(uuid4()),
+        "name": "Test Event",
+        "event_type": "League",
+        "tier": "T1",
+        "start_date": now.isoformat(),
+        "end_date": (now).isoformat(),
+        "season_number": 1,
+        "status": "upcoming",
+        "created_at": now.isoformat(),
+        "updated_at": now.isoformat(),
+    }
+
+
+@pytest.fixture
+def team_data():
+    """Sample team data used in endpoint tests."""
+    now = datetime.now(timezone.utc)
+    return {
+        "id": str(uuid4()),
+        "name": "Test Team",
+        "created_at": now.isoformat(),
+        "updated_at": now.isoformat(),
+    }

--- a/tests/test_events_endpoints.py
+++ b/tests/test_events_endpoints.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def test_get_event(client, mock_supabase, event_data):
+    """Ensure event details can be retrieved."""
+    mock_supabase.get_by_id.return_value = event_data
+
+    response = client.get(f"/v1/events/{event_data['id']}")
+    assert response.status_code == 200
+    assert response.json()["id"] == event_data["id"]

--- a/tests/test_players_endpoints.py
+++ b/tests/test_players_endpoints.py
@@ -1,7 +1,10 @@
-"""Supabase integration tests for player endpoints.
-
-These tests require a live Supabase instance and are skipped by default.
-"""
 import pytest
 
-pytest.skip("Supabase integration tests require a Supabase instance", allow_module_level=True)
+
+def test_get_player(client, mock_supabase, player_data):
+    """Ensure player profile can be retrieved."""
+    mock_supabase.fetch_by_id.return_value = player_data
+
+    response = client.get(f"/v1/players/{player_data['id']}")
+    assert response.status_code == 200
+    assert response.json()["id"] == player_data["id"]

--- a/tests/test_teams_endpoints.py
+++ b/tests/test_teams_endpoints.py
@@ -1,0 +1,10 @@
+import pytest
+
+
+def test_get_team(client, mock_supabase, team_data):
+    """Ensure team details can be retrieved."""
+    mock_supabase.get_by_id.return_value = team_data
+
+    response = client.get(f"/v1/teams/{team_data['id']}?include_players=false")
+    assert response.status_code == 200
+    assert response.json()["id"] == team_data["id"]


### PR DESCRIPTION
## Summary
- set up common pytest fixtures for mocked Supabase, auth overrides, and sample data
- disable rate limiting and add TestClient fixture for endpoint tests
- add basic endpoint tests for players, events, and teams

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688eaad9d3188328a1094b2d7e84c48f